### PR TITLE
Deploying with Zeit's NOW!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules/
+./vscode
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,15 @@
 language: node_js
 node_js: node
+services:
+- mongodb
+env:
+- CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    - ubuntu-toolchain-r-test
+    packages:
+    - mongodb-org-server
+    - g++-4.8
+script: npm test

--- a/package.json
+++ b/package.json
@@ -2,14 +2,11 @@
   "name": "node-capstone",
   "version": "1.0.0",
   "description": "\"Node capstone\"",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
+    "deploy": "now --d",
     "start": "node server.js",
     "test": "mocha ./test"
-  },
-  "engines": {
-    "node": "6.9.1",
-    "npm": "3.10.8"
   },
   "author": "Katie Baldwin",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -83,14 +83,14 @@ app.delete('/deleteUser/:id', function(req, res) {
 });
 
 
+var PORT = process.env.PORT || 8080;
 
-
-// var server = app.listen(8080, function () {
-//   var host = server.address().address;
-//   var port = server.address().port;
-//   console.log('App listening at http://%s:%s', host, port);
-// });
-// module.exports = server; 
+var server = app.listen(PORT, function () {
+  var host = server.address().address;
+  var port = server.address().port;
+  console.log('App listening at http://%s:%s', host, port);
+});
+// module.exports = server;
 
 // app.listen(process.env.PORT || 8080, () => {
 //   console.log(`Your app is listening on port ${process.env.PORT || 8080}`);
@@ -100,8 +100,8 @@ app.delete('/deleteUser/:id', function(req, res) {
 
 // app.listen(process.env.PORT || 8080)
 
-app.listen(process.env.PORT || 8080, () => { callback })
+// app.listen(process.env.PORT || 8080, () => { callback })
 
-module.exports = server; 
+module.exports = server;
 
 


### PR DESCRIPTION
# Instructions for deploying with `now`
I am leaving notes on each file changed (please look over them); but below you can find exactly what you will need to do for making your own _instance_ deployment using `now`:

FYI wonderful resource for [getting started with now](https://zeit.co/docs#getting-started).

## Installing `now`
1. Install the `now` CLI to your local machine:
```bash
npm install -g now # globally installs to your machine
```
2. Setup account with Ziet:
```bash
now --login
> Enter your email: # enter your email
> Please follow the link sent to <your email> to log in.
> Verify that the provided security code in the email matches <some weird random string of words>.
```
When you go to your email and open the corresponding email you should click on the link that will open a browser tab that will display a message saying _Token was accepted_.

3. Setting up `now` in your project:
```json
{
  "main": "must point to your server file!",
  "scripts": {
    "deploy": "now"
  }
}
```
Zeit is going to run your server code in a Linux shell and deploy it as an instance from their server; this is why `"main":` must be set to your `"server.js"`. Zeit is assuming that your server code is statically hosting content: `./public`, `./dist`, `./build`, etc.
```javascript
app.use(express.static("public")); // this is important!
```
## Deploy your app!
```bash
npm run deploy

> node-capstone@1.0.0 deploy /Users/localUser/Desktop/node-capstone
> now

> Deploying ~/Desktop/node-capstone
> Using Node.js 7.6.0 (default)
> Ready! <url.sh instance deployment of your app> (copied to clipboard) [1s]
> Upload [====================] 100% 0.0s
> Sync complete (584B) [2s]
> Initializing…
> Building
> ▲ npm install
> ⧗ Installing:
>  ‣ chai@^3.5.0
>  ‣ chai-http@^3.0.0
>  ‣ mocha@^3.2.0
>  ‣ body-parser@^1.16.0
>  ‣ express@^4.14.0
>  ‣ mongoose@^4.8.1
>  ‣ morgan@^1.7.0
>  ‣ uuid@^3.0.1
> ✓ Installed 131 modules [18s]
> ▲ npm start
> > node-capstone@1.0.0 start /home/nowuser/src
> > node server.js
> App listening at http://:::8080
> Deployment complete!
```

## Note about deploying with `now`:
You only get 20 **free** deployments a month on the free tier plan so if you are having issues getting something to work I highly advise going to the #now channel on Zeit's Slack Community page, [become a member here](https://zeit.chat). Once you have used all 20 deployments for the month the only option is make another account with another email....unless you want to pay $15/mo.